### PR TITLE
Add PublicDocument and PrivateDocument classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SolidOS Vocabulary
 
-Vocabulary and JSON-LD context for SolidOS data browser panes and views.
+Vocabulary and JSON-LD context for SolidOS: data browser panes, type indexes, and related concepts.
 
 **Namespace:** `http://w3id.org/solidos#`
 
@@ -11,6 +11,8 @@ Vocabulary and JSON-LD context for SolidOS data browser panes and views.
 | Term | Description | Status |
 |------|-------------|--------|
 | `solidos:view` | Links a resource or RDF class to a pane ES module URL | unstable |
+| `solidos:PublicDocument` | Document registered in a public type index | unstable |
+| `solidos:PrivateDocument` | Document registered in a private type index | unstable |
 
 ## Links
 

--- a/index.html
+++ b/index.html
@@ -7,14 +7,14 @@
 
     <!-- Open Graph -->
     <meta property="og:title" content="SolidOS Vocabulary" />
-    <meta property="og:description" content="Vocabulary for SolidOS data browser panes and views. Defines solidos:view for linking resources to renderers." />
+    <meta property="og:description" content="Vocabulary for SolidOS: data browser panes, type indexes, and related concepts." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://mashlib.github.io/solidos/" />
 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:title" content="SolidOS Vocabulary" />
-    <meta name="twitter:description" content="Vocabulary for SolidOS data browser panes and views. Defines solidos:view for linking resources to renderers." />
+    <meta name="twitter:description" content="Vocabulary for SolidOS: data browser panes, type indexes, and related concepts." />
 
     <link href="./vocab.jsonld" rel="alternate" type="application/ld+json" />
     <link rel="stylesheet" href="./style.css" />
@@ -71,7 +71,7 @@
             "@id": "solidos:",
             "@type": "owl:Ontology",
             "title": "SolidOS vocabulary",
-            "description": "Vocabulary for SolidOS data browser panes and views."
+            "description": "Vocabulary for SolidOS: data browser panes, type indexes, and related concepts."
           },
           {
             "@id": "solidos:view",
@@ -85,6 +85,26 @@
             },
             "range": {
               "@id": "xsd:anyURI"
+            },
+            "term_status": "unstable"
+          },
+          {
+            "@id": "solidos:PublicDocument",
+            "@type": "rdfs:Class",
+            "comment": "A document registered in a public type index, intended to be discoverable by anyone who can read the index.",
+            "label": "Public document",
+            "isDefinedBy": {
+              "@id": "solidos:"
+            },
+            "term_status": "unstable"
+          },
+          {
+            "@id": "solidos:PrivateDocument",
+            "@type": "rdfs:Class",
+            "comment": "A document registered in a private type index, intended to be discoverable only by the user and parties they authorise.",
+            "label": "Private document",
+            "isDefinedBy": {
+              "@id": "solidos:"
             },
             "term_status": "unstable"
           }

--- a/js/app.js
+++ b/js/app.js
@@ -30,7 +30,7 @@ function Category(props) {
 
   return html`
     <div>
-      <h1 id="${props.label}" onClick=${handleHeadingClick}>${props.label}</h1>
+      <h1 id="${props.id}" onClick=${handleHeadingClick}>${props.label}</h1>
       <p>Comment: ${props.comment}</p>
       <p>Term status: ${props.termStatus}</p>
     </div>
@@ -76,6 +76,7 @@ function App() {
           item => html`
             <div class="property-block">
               <${Category}
+                id="${item['@id'].split(/[:#\/]/).pop()}"
                 label="${item.label}"
                 comment=${item.comment}
                 termStatus=${item.term_status}
@@ -91,6 +92,7 @@ function App() {
         item => html`
           <div class="property-block">
             <${Category}
+              id="${item['@id'].split(/[:#\/]/).pop()}"
               label="${item.label}"
               comment=${item.comment}
               termStatus=${item.term_status}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mashlib/solidos",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "SolidOS vocabulary and JSON-LD context",
   "homepage": "http://w3id.org/solidos",
   "repository": {

--- a/vocab.jsonld
+++ b/vocab.jsonld
@@ -50,7 +50,7 @@
       "@id": "solidos:",
       "@type": "owl:Ontology",
       "title": "SolidOS vocabulary",
-      "description": "Vocabulary for SolidOS data browser panes and views."
+      "description": "Vocabulary for SolidOS: data browser panes, type indexes, and related concepts."
     },
     {
       "@id": "solidos:view",
@@ -64,6 +64,26 @@
       },
       "range": {
         "@id": "xsd:anyURI"
+      },
+      "term_status": "unstable"
+    },
+    {
+      "@id": "solidos:PublicDocument",
+      "@type": "rdfs:Class",
+      "comment": "A document registered in a public type index, intended to be discoverable by anyone who can read the index.",
+      "label": "Public document",
+      "isDefinedBy": {
+        "@id": "solidos:"
+      },
+      "term_status": "unstable"
+    },
+    {
+      "@id": "solidos:PrivateDocument",
+      "@type": "rdfs:Class",
+      "comment": "A document registered in a private type index, intended to be discoverable only by the user and parties they authorise.",
+      "label": "Private document",
+      "isDefinedBy": {
+        "@id": "solidos:"
       },
       "term_status": "unstable"
     }


### PR DESCRIPTION
## Summary

- Adds `solidos:PublicDocument` and `solidos:PrivateDocument` to `vocab.jsonld` and `index.html`, both `term_status: unstable`.
- Broadens the ontology description from "panes and views" to "panes, type indexes, and related concepts".
- Adds the two classes to the README terms table and bumps version to 0.0.3.

Closes #1

## Test plan

- [ ] `vocab.jsonld` parses as valid JSON-LD.
- [ ] `index.html` renders at https://mashlib.github.io/solidos/ after merge and lists the two new terms.
- [ ] OG / Twitter card descriptions reflect the broadened scope.