### PR TITLE
Add Wallet class

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Vocabulary and JSON-LD context for SolidOS: data browser panes, type indexes, an
 | `solidos:view` | Links a resource or RDF class to a pane ES module URL | unstable |
 | `solidos:PublicDocument` | Document registered in a public type index | unstable |
 | `solidos:PrivateDocument` | Document registered in a private type index | unstable |
+| `solidos:Wallet` | Part of a pod that holds credentials and related items | unstable |
 
 ## Links
 

--- a/index.html
+++ b/index.html
@@ -107,6 +107,16 @@
               "@id": "solidos:"
             },
             "term_status": "unstable"
+          },
+          {
+            "@id": "solidos:Wallet",
+            "@type": "rdfs:Class",
+            "comment": "A part of a Solid pod that holds credentials and related items (verifiable credentials, identity documents, keys, payment instruments, tickets, and similar). Names the storage; presentation and signing are the responsibility of wallet applications.",
+            "label": "Wallet",
+            "isDefinedBy": {
+              "@id": "solidos:"
+            },
+            "term_status": "unstable"
           }
         ]
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mashlib/solidos",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "SolidOS vocabulary and JSON-LD context",
   "homepage": "http://w3id.org/solidos",
   "repository": {

--- a/vocab.jsonld
+++ b/vocab.jsonld
@@ -86,6 +86,16 @@
         "@id": "solidos:"
       },
       "term_status": "unstable"
+    },
+    {
+      "@id": "solidos:Wallet",
+      "@type": "rdfs:Class",
+      "comment": "A part of a Solid pod that holds credentials and related items (verifiable credentials, identity documents, keys, payment instruments, tickets, and similar). Names the storage; presentation and signing are the responsibility of wallet applications.",
+      "label": "Wallet",
+      "isDefinedBy": {
+        "@id": "solidos:"
+      },
+      "term_status": "unstable"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Adds `solidos:Wallet` (`rdfs:Class`, `term_status: unstable`) to `vocab.jsonld` and `index.html`.
- Adds the class to the README terms table.
- Bumps version to 0.0.4.

The class names the **storage** of wallet contents inside a pod (credentials, identity documents, keys, payment instruments, tickets, etc.). Presentation and signing are out of scope and remain the responsibility of wallet applications.

Closes #3

## Test plan

- [ ] `vocab.jsonld` parses as valid JSON-LD.
- [ ] `index.html` renders at https://mashlib.github.io/solidos/ after merge and lists the new term.
- [ ] Heading id for the new class is `Wallet` (not `Wallet ` or with whitespace), confirming the renderer fix from #2 holds.