### PR TITLE
Render heading using class identifier, not rdfs:label

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -30,7 +30,7 @@ function Category(props) {
 
   return html`
     <div>
-      <h1 id="${props.id}" onClick=${handleHeadingClick}>${props.label}</h1>
+      <h1 id="${props.id}" onClick=${handleHeadingClick}>${props.id}</h1>
       <p>Comment: ${props.comment}</p>
       <p>Term status: ${props.termStatus}</p>
     </div>

--- a/js/app.js
+++ b/js/app.js
@@ -77,7 +77,6 @@ function App() {
             <div class="property-block">
               <${Category}
                 id="${item['@id'].split(/[:#\/]/).pop()}"
-                label="${item.label}"
                 comment=${item.comment}
                 termStatus=${item.term_status}
               />
@@ -93,7 +92,6 @@ function App() {
           <div class="property-block">
             <${Category}
               id="${item['@id'].split(/[:#\/]/).pop()}"
-              label="${item.label}"
               comment=${item.comment}
               termStatus=${item.term_status}
             />

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mashlib/solidos",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "SolidOS vocabulary and JSON-LD context",
   "homepage": "http://w3id.org/solidos",
   "repository": {


### PR DESCRIPTION
## Summary

- `js/app.js` now renders `${props.id}` (local name from `@id`) as the visible heading text, instead of `${props.label}`.
- Fixes term headings showing "Public document"/"Private document" instead of the canonical `PublicDocument`/`PrivateDocument` identifiers.
- Bumps version to 0.0.5.

The `rdfs:label` values stay in `vocab.jsonld` for tooling consumers; only the visible heading changes.

Closes #5

## Test plan

- [ ] After Pages rebuild, https://mashlib.github.io/solidos/ shows `PublicDocument`, `PrivateDocument`, `Wallet`, and `view` as headings.
- [ ] Fragment links still work (`/#PublicDocument`, etc.) — the renderer fix from #2 already aligned the `id` attribute to the local name.